### PR TITLE
Fix for Web Workers

### DIFF
--- a/msgpack.js
+++ b/msgpack.js
@@ -547,8 +547,12 @@
 		// Node.js
 		module.exports = msgpack;
 	}
-	else {
-		// Global object
+	else if (typeof WorkerGlobalScope === "function" && self instanceof WorkerGlobalScope) {
+		// Web Worker scope
+		self.msgpack = msgpack;
+	}
+	else if (typeof window === "object") {
+		// Web browser
 		window[window.msgpackJsName || "msgpack"] = msgpack;
 	}
 


### PR DESCRIPTION
fixes issues #12 and #35

It now detects the Web Worker scope properly and can be imported in a Web Worker with `self.importScripts`.


**Note: The minified build has not been rebuilt!**